### PR TITLE
Feat: 가게에 미션 추가하기 API 구현

### DIFF
--- a/src/main/java/umc8th/spring8th/converter/MissionConverter.java
+++ b/src/main/java/umc8th/spring8th/converter/MissionConverter.java
@@ -1,0 +1,29 @@
+package umc8th.spring8th.converter;
+
+import umc8th.spring8th.domain.Mission;
+import umc8th.spring8th.domain.Store;
+import umc8th.spring8th.web.dto.Mission.MissionRequestDTO;
+import umc8th.spring8th.web.dto.Mission.MissionResponseDTO;
+
+import java.time.LocalDateTime;
+
+public class MissionConverter {
+
+    public static Mission toMission(Store store, MissionRequestDTO.NewMissionDTO request) {
+
+        return Mission.builder()
+                .store(store)
+                .missionSpec(request.getMissionSpec())
+                .deadline(request.getDeadline())
+                .reward(request.getReward())
+                .build();
+    }
+
+    public static MissionResponseDTO.NewMissionResultDTO toNewMissionResultDTO(Mission mission) {
+
+        return MissionResponseDTO.NewMissionResultDTO.builder()
+                .missionId(mission.getId())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/umc8th/spring8th/service/MissionService/MissionCommandService.java
+++ b/src/main/java/umc8th/spring8th/service/MissionService/MissionCommandService.java
@@ -1,0 +1,9 @@
+package umc8th.spring8th.service.MissionService;
+
+import umc8th.spring8th.domain.Mission;
+import umc8th.spring8th.web.dto.Mission.MissionRequestDTO;
+
+public interface MissionCommandService {
+
+    Mission createMission(Long storeId, MissionRequestDTO.NewMissionDTO request);
+}

--- a/src/main/java/umc8th/spring8th/service/MissionService/MissionCommandServiceImpl.java
+++ b/src/main/java/umc8th/spring8th/service/MissionService/MissionCommandServiceImpl.java
@@ -1,0 +1,31 @@
+package umc8th.spring8th.service.MissionService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc8th.spring8th.converter.MissionConverter;
+import umc8th.spring8th.domain.Mission;
+import umc8th.spring8th.domain.Store;
+import umc8th.spring8th.repository.MissionRepository.MissionRepository;
+import umc8th.spring8th.repository.StoreRepository.StoreRepository;
+import umc8th.spring8th.web.dto.Mission.MissionRequestDTO;
+
+@Service
+@RequiredArgsConstructor
+public class MissionCommandServiceImpl implements MissionCommandService {
+
+    private final StoreRepository storeRepository;
+    private final MissionRepository missionRepository;
+
+    @Override
+    @Transactional
+    public Mission createMission(Long storeId, MissionRequestDTO.NewMissionDTO request) {
+
+        Store store = storeRepository.getReferenceById(storeId);
+
+        Mission newMission = MissionConverter.toMission(store, request);
+
+        return missionRepository.save(newMission);
+    }
+
+}

--- a/src/main/java/umc8th/spring8th/web/controller/MissionController.java
+++ b/src/main/java/umc8th/spring8th/web/controller/MissionController.java
@@ -1,24 +1,42 @@
 package umc8th.spring8th.web.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import umc8th.spring8th.apiPayload.ApiResponse;
+import umc8th.spring8th.converter.MissionConverter;
+import umc8th.spring8th.domain.Mission;
 import umc8th.spring8th.service.MissionService.MissionQueryService;
+import umc8th.spring8th.validation.annotation.ExistStore;
+import umc8th.spring8th.web.dto.Mission.MissionRequestDTO;
 import umc8th.spring8th.web.dto.Mission.MissionResponseDTO;
 
 import java.util.List;
 
 @RestController
+@Validated
 @RequestMapping("/api")
 @RequiredArgsConstructor
 public class MissionController {
 
     private final MissionQueryService missionQueryService;
+    private final MissionCommandService missionCommandService;
 
     // 홈 화면 - 특정 지역의 회원의 도전 가능한 미션 모아보기
     @GetMapping("/member/{memberId}/available-missions")
     public ApiResponse<List<MissionResponseDTO.RegionMissionDTO>> getAvailableMissions(@PathVariable Long memberId, @RequestParam String regionName) {
 
         return ApiResponse.onSuccess(missionQueryService.findAvailableMissions(memberId, regionName));
+    }
+
+    // 가게에 미션 추가
+    @PostMapping("/stores/{storeId}/missions")
+    public ApiResponse<MissionResponseDTO.NewMissionResultDTO> createMission(@PathVariable(name = "storeId") @ExistStore Long storeId,
+                                                                             @RequestBody @Valid MissionRequestDTO.NewMissionDTO request) {
+
+        Mission mission = missionCommandService.createMission(storeId, request);
+
+        return ApiResponse.onSuccess(MissionConverter.toNewMissionResultDTO(mission));
     }
 }

--- a/src/main/java/umc8th/spring8th/web/controller/MissionController.java
+++ b/src/main/java/umc8th/spring8th/web/controller/MissionController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.*;
 import umc8th.spring8th.apiPayload.ApiResponse;
 import umc8th.spring8th.converter.MissionConverter;
 import umc8th.spring8th.domain.Mission;
+import umc8th.spring8th.service.MissionService.MissionCommandService;
 import umc8th.spring8th.service.MissionService.MissionQueryService;
 import umc8th.spring8th.validation.annotation.ExistStore;
 import umc8th.spring8th.web.dto.Mission.MissionRequestDTO;

--- a/src/main/java/umc8th/spring8th/web/dto/Mission/MissionRequestDTO.java
+++ b/src/main/java/umc8th/spring8th/web/dto/Mission/MissionRequestDTO.java
@@ -2,6 +2,7 @@ package umc8th.spring8th.web.dto.Mission;
 
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 import java.time.LocalDate;
@@ -12,7 +13,7 @@ public class MissionRequestDTO {
     public static class NewMissionDTO {
         @NotBlank
         String missionSpec;
-        @NotBlank
+        @NotNull(message = "마감일은 필수입니다.")
         LocalDate deadline;
         @DecimalMin(value = "0.0", inclusive = true, message = "점수는 0 이상이어야 합니다.")
         Integer reward;

--- a/src/main/java/umc8th/spring8th/web/dto/Mission/MissionRequestDTO.java
+++ b/src/main/java/umc8th/spring8th/web/dto/Mission/MissionRequestDTO.java
@@ -1,0 +1,20 @@
+package umc8th.spring8th.web.dto.Mission;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+public class MissionRequestDTO {
+
+    @Getter
+    public static class NewMissionDTO {
+        @NotBlank
+        String missionSpec;
+        @NotBlank
+        LocalDate deadline;
+        @DecimalMin(value = "0.0", inclusive = true, message = "점수는 0 이상이어야 합니다.")
+        Integer reward;
+    }
+}

--- a/src/main/java/umc8th/spring8th/web/dto/Mission/MissionResponseDTO.java
+++ b/src/main/java/umc8th/spring8th/web/dto/Mission/MissionResponseDTO.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 public class MissionResponseDTO {
 
     @Builder
@@ -17,5 +19,14 @@ public class MissionResponseDTO {
         private Integer reward;
         private String missionSpec;
         private Integer daysLeft;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class NewMissionResultDTO {
+        private Long missionId;
+        private LocalDateTime createdAt;
     }
 }


### PR DESCRIPTION
가게에 미션 추가하기 API를 구현했습니다.

- PathVariable 에서 @ExistStore로 존재하는 가게인지 검증
- MissionRequestDTO에서 각 필드값에 대한 검증
- 모든 검증을 통과하면 미션 성공적으로 생성