### PR TITLE
Feature: JWT RefreshToken 추가 로그인 및 회원가입 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 dependencyManagement {

--- a/src/main/java/umc8th/spring8th/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc8th/spring8th/apiPayload/code/status/ErrorStatus.java
@@ -23,6 +23,7 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "MEMBER4003", "유효하지 않은 토큰입니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "MEMBER4004", "패스워드가 불일치합니다."),
     DUPLICATE_JOIN_REQUEST(HttpStatus.BAD_REQUEST, "MEMBER4005", "해당 이메일로 이미 가입된 사용자가 존재합니다."),
+    TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "MEMBER4006", "만료된 토큰입니다."),
 
     // 선호 음식 관련 에러
     FOOD_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "FOOD_CATEGORY4001", "해당되는 선호 음식이 없습니다"),

--- a/src/main/java/umc8th/spring8th/config/properties/JwtProperties.java
+++ b/src/main/java/umc8th/spring8th/config/properties/JwtProperties.java
@@ -18,6 +18,6 @@ public class JwtProperties {
     @Setter
     public static class Expiration {
         private Long access;
-        // TODO : refreshToken
+        private Long refresh;
     }
 }

--- a/src/main/java/umc8th/spring8th/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/umc8th/spring8th/config/security/jwt/JwtTokenProvider.java
@@ -16,6 +16,12 @@ import umc8th.spring8th.apiPayload.code.status.ErrorStatus;
 import umc8th.spring8th.apiPayload.exception.handler.MemberHandler;
 import umc8th.spring8th.config.properties.Constants;
 import umc8th.spring8th.config.properties.JwtProperties;
+import umc8th.spring8th.converter.MemberConverter;
+import umc8th.spring8th.domain.Member;
+import umc8th.spring8th.domain.RefreshToken;
+import umc8th.spring8th.repository.MemberRepository.MemberRepository;
+import umc8th.spring8th.repository.RefreshTokenRepository.RefreshTokenRepository;
+import umc8th.spring8th.web.dto.Member.MemberResponseDTO;
 
 import java.security.Key;
 import java.util.Collections;
@@ -26,6 +32,8 @@ import java.util.Date;
 public class JwtTokenProvider {
 
     private final JwtProperties jwtProperties;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final MemberRepository memberRepository;
 
     private Key getSigningKey() {
         return Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes());
@@ -86,11 +94,7 @@ public class JwtTokenProvider {
 
     // JWT 토큰에서 인증 정보를 추출해서, Spring Security의 Authentication 객체로 변환
     public Authentication getAuthentication(String token) {
-        Claims claims = Jwts.parserBuilder()
-                .setSigningKey(getSigningKey())
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
+        Claims claims = getClaims(token);
 
         String email = claims.getSubject();
         String role = claims.get("role", String.class);
@@ -116,5 +120,61 @@ public class JwtTokenProvider {
             throw new MemberHandler(ErrorStatus.INVALID_TOKEN);
         }
         return getAuthentication(accessToken);
+    }
+
+    // RefreshToken 유효성 확인
+    public void validateRefreshToken(String refreshToken) {
+        // 레디스에 값이 있는지 확인
+        boolean exists = refreshTokenRepository.existsById(refreshToken);
+
+        if(!exists) {
+            throw new MemberHandler(ErrorStatus.INVALID_TOKEN);
+        }
+    }
+
+    // 토큰의 클레임 가져오기
+    public Claims getClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey())
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (Exception e) {
+            throw new MemberHandler(ErrorStatus.INVALID_TOKEN);
+        }
+    }
+
+    // 토큰 재발급
+    public MemberResponseDTO.LoginResultDTO reissueToken(String refreshToken) {
+
+        RefreshToken refreshTokenEntity = refreshTokenRepository.findById(refreshToken)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.INVALID_TOKEN));
+
+        Member member = memberRepository.findById(refreshTokenEntity.getUserId())
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 새로운 인증 객체 Authentication 생성
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                member.getEmail(),
+                null,
+                Collections.singleton(() -> member.getRole().name())
+        );
+
+        // 새로운 AccessToken, RefreshToken 생성
+        String newAccessToken = generateToken(authentication);
+        String newRefreshToken = generateRefreshToken(authentication);
+
+        // 기존 RefreshToken 삭제
+        refreshTokenRepository.delete(refreshTokenEntity);
+        // 새로운 RefreshToken 생성 및 저장
+        RefreshToken newRefreshTokenEntity = new RefreshToken(newRefreshToken, member.getId());
+        refreshTokenRepository.save(newRefreshTokenEntity);
+
+        return MemberConverter.toLoginResultDTO(
+                member.getId(),
+                newAccessToken,
+                newRefreshToken
+        );
     }
 }

--- a/src/main/java/umc8th/spring8th/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/umc8th/spring8th/config/security/jwt/JwtTokenProvider.java
@@ -33,13 +33,38 @@ public class JwtTokenProvider {
 
     // 인증 정보를 받아서, JWT Access Token을 생성하고 반환
     public String generateToken(Authentication authentication) {
-        String email = authentication.getName();;
+        String email = authentication.getName();
+
+        return Jwts.builder()
+                // 페이로드의 sub 클레임 설정
+                // 토큰의 주체를 나타내며 일반적으로 사용자 식별자(이메일, 아이디) 저장
+                // 사용자를 고유하게 식별할 수 있는 값
+                .setSubject(email)
+                // 사용자 정의(custom) 클레임 추가
+                // "role"은 클레임 이름
+                // 사용자의 권한 (ex. ROLE_USER)를 가져옴
+                .claim("role", authentication.getAuthorities().iterator().next().getAuthority())
+                // 토큰이 발행된 시간 설정 (현재 시간)
+                .setIssuedAt(new Date())
+                // 토큰의 만료 시간을 지정
+                // 현재 시간에 만료 시간을 더함
+                .setExpiration(new Date(System.currentTimeMillis() + jwtProperties.getExpiration().getAccess()))
+                // 서명을 생성
+                // 비밀키를 가져와 알고리즘을 사용해 서명
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                // 설정된 내용을 바탕으로 최종 JWT 문자열을 생성
+                .compact();
+    }
+
+    // Refresh Token 생성하고 반환
+    public String generateRefreshToken(Authentication authentication) {
+        String email = authentication.getName();
 
         return Jwts.builder()
                 .setSubject(email)
                 .claim("role", authentication.getAuthorities().iterator().next().getAuthority())
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + jwtProperties.getExpiration().getAccess()))
+                .setExpiration(new Date(System.currentTimeMillis() + jwtProperties.getExpiration().getRefresh()))
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256)
                 .compact();
     }

--- a/src/main/java/umc8th/spring8th/converter/MemberConverter.java
+++ b/src/main/java/umc8th/spring8th/converter/MemberConverter.java
@@ -46,10 +46,11 @@ public class MemberConverter {
                 .build();
     }
 
-    public static MemberResponseDTO.LoginResultDTO toLoginResultDTO(Long memberId, String accessToken) {
+    public static MemberResponseDTO.LoginResultDTO toLoginResultDTO(Long memberId, String accessToken, String refreshToken) {
         return MemberResponseDTO.LoginResultDTO.builder()
                 .memberId(memberId)
                 .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .build();
     }
 

--- a/src/main/java/umc8th/spring8th/domain/RefreshToken.java
+++ b/src/main/java/umc8th/spring8th/domain/RefreshToken.java
@@ -1,0 +1,19 @@
+package umc8th.spring8th.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@RedisHash(value = "refreshToken", timeToLive = 1209600)
+public class RefreshToken {
+
+    @Id
+    private String refreshToken;
+    private Long userId;
+
+    public RefreshToken(String refreshToken, Long userId) {
+        this.refreshToken = refreshToken;
+        this.userId = userId;
+    }
+}

--- a/src/main/java/umc8th/spring8th/repository/RefreshTokenRepository/RefreshTokenRepository.java
+++ b/src/main/java/umc8th/spring8th/repository/RefreshTokenRepository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package umc8th.spring8th.repository.RefreshTokenRepository;
+
+import org.springframework.data.repository.CrudRepository;
+import umc8th.spring8th.domain.RefreshToken;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+}

--- a/src/main/java/umc8th/spring8th/service/AuthService/AuthCommandService.java
+++ b/src/main/java/umc8th/spring8th/service/AuthService/AuthCommandService.java
@@ -1,0 +1,8 @@
+package umc8th.spring8th.service.AuthService;
+
+import umc8th.spring8th.web.dto.Member.MemberResponseDTO;
+
+public interface AuthCommandService {
+
+    MemberResponseDTO.LoginResultDTO reissueToken(String refreshToken);
+}

--- a/src/main/java/umc8th/spring8th/service/AuthService/AuthCommandServiceImpl.java
+++ b/src/main/java/umc8th/spring8th/service/AuthService/AuthCommandServiceImpl.java
@@ -1,0 +1,29 @@
+package umc8th.spring8th.service.AuthService;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc8th.spring8th.apiPayload.code.status.ErrorStatus;
+import umc8th.spring8th.apiPayload.exception.handler.MemberHandler;
+import umc8th.spring8th.config.security.jwt.JwtTokenProvider;
+import umc8th.spring8th.web.dto.Member.MemberResponseDTO;
+
+@Service
+@RequiredArgsConstructor
+public class AuthCommandServiceImpl implements AuthCommandService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public MemberResponseDTO.LoginResultDTO reissueToken(String refreshToken) {
+        try {
+            jwtTokenProvider.validateRefreshToken(refreshToken);
+            return jwtTokenProvider.reissueToken(refreshToken);
+        } catch (ExpiredJwtException eje) {
+            throw new MemberHandler(ErrorStatus.TOKEN_EXPIRED);
+        } catch (IllegalArgumentException iae) {
+            throw new MemberHandler(ErrorStatus.INVALID_TOKEN);
+        }
+    }
+
+}

--- a/src/main/java/umc8th/spring8th/service/MemberService/MemberCommandServiceImpl.java
+++ b/src/main/java/umc8th/spring8th/service/MemberService/MemberCommandServiceImpl.java
@@ -13,9 +13,11 @@ import umc8th.spring8th.converter.MemberConverter;
 import umc8th.spring8th.converter.MemberPreferConverter;
 import umc8th.spring8th.domain.FoodCategory;
 import umc8th.spring8th.domain.Member;
+import umc8th.spring8th.domain.RefreshToken;
 import umc8th.spring8th.domain.mapping.MemberPrefer;
 import umc8th.spring8th.repository.FoodCategoryRepository.FoodCategoryRepository;
 import umc8th.spring8th.repository.MemberRepository.MemberRepository;
+import umc8th.spring8th.repository.RefreshTokenRepository.RefreshTokenRepository;
 import umc8th.spring8th.web.dto.Member.MemberRequestDTO;
 import umc8th.spring8th.web.dto.Member.MemberResponseDTO;
 
@@ -33,6 +35,8 @@ public class MemberCommandServiceImpl implements  MemberCommandService{
     private final PasswordEncoder passwordEncoder;
 
     private final JwtTokenProvider jwtTokenProvider;
+
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Override
     @Transactional
@@ -75,10 +79,16 @@ public class MemberCommandServiceImpl implements  MemberCommandService{
         );
 
         String accessToken = jwtTokenProvider.generateToken(authentication);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(authentication);
+
+        // Redis에 RefreshToken 저장
+        RefreshToken refreshTokenEntity = new RefreshToken(refreshToken, member.getId());
+        refreshTokenRepository.save(refreshTokenEntity);
 
         return MemberConverter.toLoginResultDTO(
                 member.getId(),
-                accessToken
+                accessToken,
+                refreshToken
         );
     }
 }

--- a/src/main/java/umc8th/spring8th/web/controller/AuthController.java
+++ b/src/main/java/umc8th/spring8th/web/controller/AuthController.java
@@ -1,0 +1,28 @@
+package umc8th.spring8th.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc8th.spring8th.apiPayload.ApiResponse;
+import umc8th.spring8th.service.AuthService.AuthCommandService;
+import umc8th.spring8th.web.dto.Member.MemberResponseDTO;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthCommandService authCommandService;
+
+    @Operation(summary = "토큰 재발급", description = "accessToken이 만료 시 refreshToken을 통해 accessToken을 재발급합니다.")
+    @PostMapping("/reissue")
+    @Parameter(name = "refreshToken", description = "리프레시 토큰")
+    public ApiResponse<MemberResponseDTO.LoginResultDTO> reissueToken(@RequestHeader("refreshToken") String refreshToken) {
+
+        return ApiResponse.onSuccess(authCommandService.reissueToken(refreshToken));
+    }
+}

--- a/src/main/java/umc8th/spring8th/web/dto/Member/MemberResponseDTO.java
+++ b/src/main/java/umc8th/spring8th/web/dto/Member/MemberResponseDTO.java
@@ -37,6 +37,7 @@ public class MemberResponseDTO {
     public static class LoginResultDTO {
         Long memberId;
         String accessToken;
+        String refreshToken;
     }
 
     @Builder

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,3 +27,4 @@ jwt:
     secretKey: umceightfightingjwttokenauthentication
     expiration:
       access: 14400000
+      refresh: 1209600000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,11 @@ spring:
         default_batch_fetch_size: 1000
   profiles:
     active: local
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
 discord:
   webhook:
     enabled: false


### PR DESCRIPTION
- resolve issue : #23 
- docker에 redis 설치하여 refreshToken 관리
- 로그인할 때 accessToken과 refreshToken을 생성하여 응답으로 반환
- 토큰 재발급 기능 구현
- Header에 기존 refreshToken을 담아서 보내면 Redis에서 기존 refreshToken을 삭제하고 새로 생성